### PR TITLE
Add cgbn_swap

### DIFF
--- a/docs/CGBN.md
+++ b/docs/CGBN.md
@@ -106,6 +106,12 @@ For more complete examples, including proper error handling, please see the samp
 
 Copies the CGBN value of **_a_** into **_r_**. &nbsp; No return value.
 
+##### Swap
+
+`void cgbn_swap(cgbn_env_t env, cgbn_t &r, cgbn_t &a)`
+
+Swaps the CGBN value of **_a_** and **_r_**. &nbsp; No return value.
+
 ##### Addition and Subtraction
 
 `int32_t cgbn_add(cgbn_env_t env, cgbn_t &r, const cgbn_t &a, const cgbn_t &b)`

--- a/include/cgbn/cgbn.h
+++ b/include/cgbn/cgbn.h
@@ -88,6 +88,11 @@ __host__ __device__ __forceinline__ void cgbn_set(env_t env, typename env_t::cgb
 }
 
 template<class env_t>
+__host__ __device__ __forceinline__ void cgbn_swap(env_t env, typename env_t::cgbn_t &r, typename env_t::cgbn_t &a) {
+  env.swap(r, a);
+}
+
+template<class env_t>
 __host__ __device__ __forceinline__ int32_t cgbn_add(env_t env, typename env_t::cgbn_t &r, const typename env_t::cgbn_t &a, const typename env_t::cgbn_t &b) {
   return env.add(r, a, b);
 }

--- a/include/cgbn/cgbn_cuda.h
+++ b/include/cgbn/cgbn_cuda.h
@@ -145,6 +145,7 @@ class cgbn_env_t {
 
   /* bn arithmetic routines */
   __device__ __forceinline__ void       set(cgbn_t &r, const cgbn_t &a) const;
+  __device__ __forceinline__ void       swap(cgbn_t &r, cgbn_t &a) const;
   __device__ __forceinline__ int32_t    add(cgbn_t &r, const cgbn_t &a, const cgbn_t &b) const;
   __device__ __forceinline__ int32_t    sub(cgbn_t &r, const cgbn_t &a, const cgbn_t &b) const;
   __device__ __forceinline__ int32_t    negate(cgbn_t &r, const cgbn_t &a) const;

--- a/include/cgbn/cgbn_mpz.h
+++ b/include/cgbn/cgbn_mpz.h
@@ -148,6 +148,7 @@ class cgbn_env_t {
 
   /* set/get routines */
   __host__ void       set(cgbn_t &r, const cgbn_t &a) const;
+  __host__ void       swap(cgbn_t &r, cgbn_t &a) const;
   __host__ void       extract_bits(cgbn_t &r, const cgbn_t &a, uint32_t start, uint32_t len) const;
   __host__ void       insert_bits(cgbn_t &r, const cgbn_t &a, uint32_t start, uint32_t len, const cgbn_t &value) const;
 

--- a/include/cgbn/core/core.cu
+++ b/include/cgbn/core/core.cu
@@ -183,6 +183,9 @@ class core_t {
   __device__ __forceinline__ static void     set(uint32_t r[LIMBS], const uint32_t a[LIMBS]) {
     mpset<LIMBS>(r, a);
   }
+  __device__ __forceinline__ static void     swap(uint32_t r[LIMBS], uint32_t a[LIMBS]) {
+    mpswap<LIMBS>(r, a);
+  }
   
   /* BASIC ARITHMETIC */
   __device__ __forceinline__ static int32_t  add(uint32_t r[LIMBS], const uint32_t a[LIMBS], const uint32_t b[LIMBS]);

--- a/include/cgbn/impl_cuda.cu
+++ b/include/cgbn/impl_cuda.cu
@@ -170,6 +170,11 @@ __device__ __forceinline__ void cgbn_env_t<context_t, bits, syncable>::set(cgbn_
   cgbn::core_t<cgbn_env_t>::set(r._limbs, a._limbs);
 }
 
+template<class context_t, uint32_t bits, cgbn_syncable_t syncable>
+__device__ __forceinline__ void cgbn_env_t<context_t, bits, syncable>::swap(cgbn_t &r, cgbn_t &a) const {
+  cgbn::core_t<cgbn_env_t>::swap(r._limbs, a._limbs);
+}
+
 template<class context_t, uint32_t bits, cgbn_syncable_t syncable> template<class source_cgbn_t>
 __device__ __forceinline__ void cgbn_env_t<context_t, bits, syncable>::set(cgbn_t &r, const source_cgbn_t &source) const {
   uint32_t sync, group_thread=threadIdx.x & TPI-1;

--- a/include/cgbn/impl_mpz.cc
+++ b/include/cgbn/impl_mpz.cc
@@ -143,6 +143,11 @@ void cgbn_env_t<context_t, bits, convergence>::set(cgbn_t &r, const cgbn_t &a) c
 }
 
 template<class context_t, uint32_t bits, cgbn_convergence_t convergence>
+void cgbn_env_t<context_t, bits, convergence>::swap(cgbn_t &r, cgbn_t &a) const {
+  mpz_swap(r._z, a._z);
+}
+
+template<class context_t, uint32_t bits, cgbn_convergence_t convergence>
 void cgbn_env_t<context_t, bits, convergence>::extract_bits(cgbn_t &r, const cgbn_t &a, const uint32_t start, const uint32_t len) const {
   mpz_fdiv_q_2exp(r._z, a._z, start);
   mpz_fdiv_r_2exp(r._z, r._z, len);

--- a/unit_tests/tester.cu
+++ b/unit_tests/tester.cu
@@ -31,7 +31,8 @@ IN THE SOFTWARE.
 #include "sizes.h"
 
 typedef enum test_enum {
-  test_set_1, test_add_1, test_negate_1, test_sub_1, test_mul_1, test_mul_high_1, test_sqr_1, test_sqr_high_1, test_div_1, test_rem_1,
+  test_set_1, test_swap_1, test_add_1, test_negate_1, test_sub_1,
+  test_mul_1, test_mul_high_1, test_sqr_1, test_sqr_high_1, test_div_1, test_rem_1,
   test_div_rem_1, test_sqrt_1, test_sqrt_rem_1, test_equals_1, test_equals_2, test_equals_3, test_compare_1, test_compare_2,
   test_compare_3, test_compare_4, test_extract_bits_1, test_insert_bits_1,
   

--- a/unit_tests/tests/swap.h
+++ b/unit_tests/tests/swap.h
@@ -1,0 +1,49 @@
+/***
+
+Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+***/
+
+template<class params>
+struct implementation<test_swap_1, params> {
+  static const uint32_t TPI=params::TPI;
+  static const uint32_t BITS=params::BITS;
+
+  typedef cgbn_context_t<TPI, params>    context_t;
+  typedef cgbn_env_t<context_t, BITS>    env_t;
+  typedef typename env_t::cgbn_t         bn_t;
+
+  public:
+  __device__ __host__ static void run(typename types<params>::input_t *inputs, typename types<params>::output_t *outputs, int32_t instance) {
+    context_t context(cgbn_print_monitor);
+    env_t     env(context);
+    bn_t      h1, x1;
+
+    cgbn_load(env, h1, &(inputs[instance].h1));
+    cgbn_load(env, x1, &(inputs[instance].x1));
+
+    cgbn_swap(env, h1, x1);
+
+    cgbn_store(env, &(outputs[instance].r1), h1);
+    cgbn_store(env, &(outputs[instance].r2), x1);
+  }
+};
+

--- a/unit_tests/tests/tests.h
+++ b/unit_tests/tests/tests.h
@@ -23,6 +23,7 @@ IN THE SOFTWARE.
 ***/
 
 #include "set.h"
+#include "swap.h"
 #include "extract_bits.h"
 #include "insert_bits.h"
 #include "add.h"

--- a/unit_tests/unit_tests.cc
+++ b/unit_tests/unit_tests.cc
@@ -102,8 +102,14 @@ TYPED_TEST_SUITE_P(CGBN4);
 TYPED_TEST_SUITE_P(CGBN5);
 
 TYPED_TEST_P(CGBN1, set_1) {
-  bool result=run_test<test_add_1, TestFixture>(LONG_TEST);
-  
+  bool result=run_test<test_set_1, TestFixture>(LONG_TEST);
+
+  EXPECT_TRUE(result);
+}
+
+TYPED_TEST_P(CGBN1, swap_1) {
+  bool result=run_test<test_swap_1, TestFixture>(LONG_TEST);
+
   EXPECT_TRUE(result);
 }
 
@@ -576,13 +582,14 @@ TYPED_TEST_P(CGBN5, barrett_div_rem_wide_1) {
   EXPECT_TRUE(result);
 }
 
-REGISTER_TYPED_TEST_SUITE_P(CGBN1, 
- set_1, add_1, sub_1, negate_1, mul_1, mul_high_1, sqr_1, sqr_high_1, div_1, rem_1, div_rem_1, sqrt_1, 
+REGISTER_TYPED_TEST_SUITE_P(CGBN1,
+ set_1, swap_1, add_1, sub_1, negate_1,
+ mul_1, mul_high_1, sqr_1, sqr_high_1, div_1, rem_1, div_rem_1, sqrt_1,
  sqrt_rem_1, equals_1, equals_2, equals_3, compare_1, compare_2, compare_3, compare_4,
  extract_bits_1, insert_bits_1
 );
-REGISTER_TYPED_TEST_SUITE_P(CGBN2, 
- get_ui32_set_ui32_1, add_ui32_1, sub_ui32_1, mul_ui32_1, div_ui32_1, rem_ui32_1, 
+REGISTER_TYPED_TEST_SUITE_P(CGBN2,
+ get_ui32_set_ui32_1, add_ui32_1, sub_ui32_1, mul_ui32_1, div_ui32_1, rem_ui32_1,
  equals_ui32_1, equals_ui32_2, equals_ui32_3, equals_ui32_4, compare_ui32_1, compare_ui32_2,
  extract_bits_ui32_1, insert_bits_ui32_1, binary_inverse_ui32_1, gcd_ui32_1
 );


### PR DESCRIPTION
Uses `mpswap<LIMBS>` which was already written for GCD.

Added and ran tests
```
[==========] Running 880 tests from 55 test suites.
[----------] Global test environment set-up.
[----------] 23 tests from S32T4/CGBN1/0, where TypeParam = size32t4
[ RUN      ] S32T4/CGBN1/0.set_1
[       OK ] S32T4/CGBN1/0.set_1 (577 ms)
[ RUN      ] S32T4/CGBN1/0.swap_1
[       OK ] S32T4/CGBN1/0.swap_1 (29 ms)
...
[----------] 23 tests from S3072T32/CGBN1/0, where TypeParam = size3072t32
[ RUN      ] S3072T32/CGBN1/0.set_1
[       OK ] S3072T32/CGBN1/0.set_1 (1944 ms)
[ RUN      ] S3072T32/CGBN1/0.swap_1
[       OK ] S3072T32/CGBN1/0.swap_1 (434 ms)
...
[ RUN      ] S8192T32/CGBN1/0.set_1
[       OK ] S8192T32/CGBN1/0.set_1 (1793 ms)
[ RUN      ] S8192T32/CGBN1/0.swap_1
[       OK ] S8192T32/CGBN1/0.swap_1 (429 ms)
...
[----------] Global test environment tear-down
[==========] 880 tests from 55 test suites ran. (259412 ms total)
[  PASSED  ] 880 tests.
```