### PR TITLE
Fix make download-gtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ clean:
 	make -C perf_tests clean
 
 download-gtest:
-	wget 'https://github.com/google/googletest/archive/master.zip' -O googletest-master.zip
-	unzip googletest-master.zip 'googletest-master/googletest/*'
-	mv googletest-master/googletest gtest
-	rmdir googletest-master
-	rm -f googletest-master.zip
+	wget 'https://github.com/google/googletest/archive/main.zip' -O googletest-main.zip
+	unzip googletest-main.zip 'googletest-main/googletest/*'
+	mv googletest-main/googletest gtest
+	rmdir googletest-main
+	rm -f googletest-main.zip
 
 kepler: check
 	make -C samples kepler


### PR DESCRIPTION
The master branch has been renamed main which broke the download.