### PR TITLE
Mark non-templated functions inline

### DIFF
--- a/include/cgbn/cgbn.cu
+++ b/include/cgbn/cgbn.cu
@@ -22,7 +22,7 @@ IN THE SOFTWARE.
 
 ***/
 
-cudaError_t cgbn_error_report_alloc(cgbn_error_report_t **report) {
+inline cudaError_t cgbn_error_report_alloc(cgbn_error_report_t **report) {
   cudaError_t status;
 
   status=cudaMallocManaged((void **)report, sizeof(cgbn_error_report_t));
@@ -39,15 +39,15 @@ cudaError_t cgbn_error_report_alloc(cgbn_error_report_t **report) {
   return status;
 }
 
-cudaError_t cgbn_error_report_free(cgbn_error_report_t *report) {
+inline cudaError_t cgbn_error_report_free(cgbn_error_report_t *report) {
   return cudaFree(report);
 }
 
-bool cgbn_error_report_check(cgbn_error_report_t *report) {
+inline bool cgbn_error_report_check(cgbn_error_report_t *report) {
   return report->_error!=cgbn_no_error;
 }
 
-void cgbn_error_report_reset(cgbn_error_report_t *report) {
+inline void cgbn_error_report_reset(cgbn_error_report_t *report) {
   report->_error=cgbn_no_error;
   report->_instance=0xFFFFFFFFu;
   report->_threadIdx.x=0xFFFFFFFFu;
@@ -58,7 +58,7 @@ void cgbn_error_report_reset(cgbn_error_report_t *report) {
   report->_blockIdx.z=0xFFFFFFFFu;
 }
 
-const char *cgbn_error_string(cgbn_error_report_t *report) {
+inline const char *cgbn_error_string(cgbn_error_report_t *report) {
   if(report->_error==cgbn_no_error)
     return NULL;
   switch(report->_error) {


### PR DESCRIPTION
This fixes one-definition rule for projects with multiple .cu files and avoids this


```
/usr/bin/ld: ./.libs/libecm.a(gpu_ecm.o): in function `cgbn_error_report_free(cgbn_error_report_t*)':
tmpxft_001fb45d_00000000-6_gpu_ecm.cudafe1.cpp:(.text+0x250): multiple definition of `cgbn_error_report_free(cgbn_error_report_t*)'; ./.libs/libecm.a(gpu_pm1.o):tmpxft_001f2a7e_00000000-6_gpu_pm1.cudafe1.cpp:(.text+0x250): first defined here
/usr/bin/ld: ./.libs/libecm.a(gpu_ecm.o): in function `cgbn_error_report_check(cgbn_error_report_t*)':
tmpxft_001fb45d_00000000-6_gpu_ecm.cudafe1.cpp:(.text+0x260): multiple definition of `cgbn_error_report_check(cgbn_error_report_t*)'; ./.libs/libecm.a(gpu_pm1.o):tmpxft_001f2a7e_00000000-6_gpu_pm1.cudafe1.cpp:(.text+0x260): first defined here
/usr/bin/ld: ./.libs/libecm.a(gpu_ecm.o): in function `cgbn_error_report_reset(cgbn_error_report_t*)':
tmpxft_001fb45d_00000000-6_gpu_ecm.cudafe1.cpp:(.text+0x270): multiple definition of `cgbn_error_report_reset(cgbn_error_report_t*)'; ./.libs/libecm.a(gpu_pm1.o):tmpxft_001f2a7e_00000000-6_gpu_pm1.cudafe1.cpp:(.text+0x270): first defined here
/usr/bin/ld: ./.libs/libecm.a(gpu_ecm.o): in function `cgbn_error_string(cgbn_error_report_t*)':
tmpxft_001fb45d_00000000-6_gpu_ecm.cudafe1.cpp:(.text+0x2a0): multiple definition of `cgbn_error_string(cgbn_error_report_t*)'; ./.libs/libecm.a(gpu_pm1.o):tmpxft_001f2a7e_00000000-6_gpu_pm1.cudafe1.cpp:(.text+0x2a0): first defined here
collect2: error: ld returned 1 exit status
```